### PR TITLE
Fix incorrect public key serialization in CKD_priv() for non-hardened indices BIP32

### DIFF
--- a/bip32/bip32.cpp
+++ b/bip32/bip32.cpp
@@ -45,7 +45,7 @@ std::vector<uint32_t> parsePath(const std::string path){
 	return parsedPath;
 }
 
-std::vector<unsigned char> getPublicKeyFromPrivateKey(const std::vector<unsigned char>& private_key, CoinType coin){
+std::vector<unsigned char> getPublicKeyFromPrivateKey(const std::vector<unsigned char>& private_key, bool toCompress){
 	EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_secp256k1);
 	BN_CTX* ctx = BN_CTX_new();
 	BIGNUM* private_key_bn = BN_new();
@@ -55,7 +55,6 @@ std::vector<unsigned char> getPublicKeyFromPrivateKey(const std::vector<unsigned
 	EC_POINT* public_key_point = EC_POINT_new(group);
 	EC_POINT_mul(group, public_key_point, private_key_bn, nullptr, nullptr, ctx);
 
-	bool toCompress = requiresCompressedPublicKey(coin);
 	size_t bytes = toCompress? 33 : 65;
 	std::vector<unsigned char> public_key(bytes);
 
@@ -102,7 +101,9 @@ std::pair<std::vector<unsigned char>, std::vector<unsigned char>> CKD_priv(
 	}
 	else{ // Non-hardened
 		// data = ser_p(point(parent_private_key)) + ser_32(index)
-		data = getPublicKeyFromPrivateKey(parent_private_key, coin);
+
+		// Does ser_p(point(parent_private_key))
+		data = getPublicKeyFromPrivateKey(parent_private_key, /*toCompress=*/true);
 	}
 	data.insert(data.end(), serialized_be_index.begin(), serialized_be_index.end());
 

--- a/bip32/bip32.h
+++ b/bip32/bip32.h
@@ -28,7 +28,7 @@ std::pair<std::vector<unsigned char>, std::vector<unsigned char>> CKD_priv(
 //////////////////////////////////////////////////////////////////////////////////
 //				Generate Public Key
 //////////////////////////////////////////////////////////////////////////////////
-std::vector<unsigned char> getPublicKeyFromPrivateKey(const std::vector<unsigned char>& private_key, CoinType coin);
+std::vector<unsigned char> getPublicKeyFromPrivateKey(const std::vector<unsigned char>& private_key, bool toCompress);
 
 //////////////////////////////////////////////////////////////////////////////////
 //				Generate Public Key

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,7 @@ int main(){
 		final_chain_code = std::move(chain_code);
 	}
 
-	std::vector<unsigned char> final_public_key = getPublicKeyFromPrivateKey(final_private_key, coin);
+	std::vector<unsigned char> final_public_key = getPublicKeyFromPrivateKey(final_private_key, requiresCompressedPublicKey(coin));
 	std::vector<unsigned char> address = getAddress(final_public_key, coin);
 
 	std::cout << "Final chain code   = ";


### PR DESCRIPTION
This PR fixes a critical bug in the non-hardened child key derivation (CKD_priv) where the public key was not being serialized in compressed format as required by BIP32.
Previously, the public key was generated but not serialized properly, leading to incorrect HMAC-SHA512 inputs and thus incorrect derived keys and chain code.

The corrected logic now follows:
`data = ser_p(point(parent_private_key)) + ser_32(index)` (for non-hardened indices)

Changes:
* Replaced CoinType argument in getPublicKeyFromPrivateKey() with a bool toCompress flag.
* Now, CKD_priv always uses toCompress = true for non-hardened derivation ser_P.
* And, main.cpp decides compression format based on coin type via requiresCompressedPublicKey(...).